### PR TITLE
Use inline hard-coded answer URL value

### DIFF
--- a/NexmoDotNetQuickStarts/Controllers/VoiceController.cs
+++ b/NexmoDotNetQuickStarts/Controllers/VoiceController.cs
@@ -22,7 +22,6 @@ namespace NexmoDotNetQuickStarts.Controllers
         {
             var NEXMO_FROM_NUMBER = Configuration.Instance.Settings["appsettings:NEXMO_FROM_NUMBER"];
             var NEXMO_TO_NUMBER = to;
-            var NEXMO_CALL_ANSWER_URL = "https://nexmo-community.github.io/ncco-examples/first_call_talk.json";
 
             var results = Call.Do(new Call.CallCommand
             {
@@ -40,7 +39,7 @@ namespace NexmoDotNetQuickStarts.Controllers
                 },
                 answer_url = new[]
                 {
-                    NEXMO_CALL_ANSWER_URL
+                    "https://nexmo-community.github.io/ncco-examples/first_call_talk.json"
                 }
             });
             var result = new HttpStatusCodeResult(200);


### PR DESCRIPTION
Other language examples just inline the answer URL. This means you can see a real NCCO in the example on Nexmo Developer too.