### PR TITLE
Standardize Verify 'to' and 'brand' vars

### DIFF
--- a/NexmoDotNetQuickStarts/Controllers/VerifyController.cs
+++ b/NexmoDotNetQuickStarts/Controllers/VerifyController.cs
@@ -30,12 +30,12 @@ namespace NexmoDotNetQuickStarts.Controllers
         [HttpPost]
         public ActionResult Start(string to)
         {
-            var TO_NUMBER = to;
+            var RECIPIENT_NUMBER = to;
 
             var start = Client.NumberVerify.Verify(new NumberVerify.VerifyRequest
             {
-                number = TO_NUMBER,
-                brand = "NexmoQS"
+                number = RECIPIENT_NUMBER,
+                brand = "AcmeInc"
             });
 
             Session["requestID"] = start.request_id;


### PR DESCRIPTION
- Changed `TO_NUMBER` to `RECIPIENT_NUMBER`
- Changed `brand` to `AcmeInc`

As discussed in [this Slack thread](https://nexmo.slack.com/archives/GCYA1C6UE/p1542800167041000), we want to use `RECIPIENT_NUMBER` instead of `NEXMO_TO_NUMBER`.

[DEVX-640](https://nexmoinc.atlassian.net/browse/DEVX-640) ticket raised to change this across all building blocks.